### PR TITLE
Fix #165: Expenses not showing correctly in listtrip after application restart 

### DIFF
--- a/src/main/java/seedu/traveltrio/Storage.java
+++ b/src/main/java/seedu/traveltrio/Storage.java
@@ -117,6 +117,10 @@ public class Storage {
                     ui.showError("Line wrongly formatted found. [" + line + "]. Check formatting.");
                 }
             }
+
+            for (int i = 0; i < trips.size(); i++) {
+                trips.get(i).getBudgets().recalculateTotalExpense();
+            }
         } catch (Exception e) {
             logger.log(Level.FINE, "Failed to load trips from " + file.getPath(), e);
             throw new TravelTrioException("Error reading file. File might be corrupted.");

--- a/src/main/java/seedu/traveltrio/model/budget/BudgetList.java
+++ b/src/main/java/seedu/traveltrio/model/budget/BudgetList.java
@@ -138,4 +138,14 @@ public class BudgetList {
     public boolean isEmpty() {
         return budgets.isEmpty();
     }
+
+    /**
+     * Recalculates the totalTripExpense from actual spendings of activities.
+     */
+    public void recalculateTotalExpense() {
+        totalTripExpense = 0;
+        for (Budget budget : budgets.values()) {
+            totalTripExpense += budget.getActualExpense();
+        }
+    }
 }


### PR DESCRIPTION
- Fixed a bug where expenses set using `setexpense` were not displayed correctly in `listtrip` after restarting the application.
- Added `recalculateTotalExpense()` method to `BudgetList` that sums up all individual budget expenses 

Fixes #165 